### PR TITLE
Add parameter "Geomagic_robot_description"

### DIFF
--- a/geomagic_control/launch/geomagic.launch
+++ b/geomagic_control/launch/geomagic.launch
@@ -1,6 +1,6 @@
 <launch>
   <include file="$(find geomagic_control)/launch/geomagic_headless.launch" />
   <!-- rviz just lets you see the end result :) -->
+  <param name="Geomagic_robot_description" command="cat $(find geomagic_description)/urdf/omni.urdf" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find geomagic_control)/cfg/omni.rviz" required="true" />
 </launch>
-


### PR DESCRIPTION
rviz won't display the robot model if the parameter pointing to
geomagic_description/urdf/omni.urdf is missing. RobotModel will
throw the error: "Parameter [Geomagic_robot_description] does not exist,
and was not found by searchParam()".